### PR TITLE
handle un-jsonifable objects

### DIFF
--- a/lib/convert.py
+++ b/lib/convert.py
@@ -8,10 +8,15 @@ try:
 except ImportError:
     import pickle
 
+def jsonhandler(obj):
+    if hasattr(obj, 'isoformat'):
+        return obj.isoformat()
+    return "[unserializable]"
+
 def main(argv):
     try:
         if argv[0] == '--loads':
-            json.dump(pickle.load(sys.stdin), sys.stdout)
+            json.dump(pickle.load(sys.stdin), sys.stdout, default=jsonhandler)
         elif argv[0] == '--dumps':
             pickle.dump(json.load(sys.stdin), sys.stdout)
     except:


### PR DESCRIPTION
Thank you for your admittedly-lazy pickle interface! This change will keep it from crashing inexplicably when it jsonifies pickled objects that aren't easily jsonifiable. And also do something sane with datetime objects. 
